### PR TITLE
Allow user option to avoid auto replace on textfield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/AutocompletionTableView_Demo/ACDViewController.h
+++ b/AutocompletionTableView_Demo/ACDViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ACDViewController : UIViewController
+@protocol AutocompletionTableViewDelegate;
+
+@interface ACDViewController : UIViewController <AutocompletionTableViewDelegate>
 
 @end

--- a/AutocompletionTableView_Demo/ACDViewController.m
+++ b/AutocompletionTableView_Demo/ACDViewController.m
@@ -31,6 +31,7 @@
         [options setValue:nil forKey:ACOUseSourceFont];
         
         _autoCompleter = [[AutocompletionTableView alloc] initWithTextField:self.textField inViewController:self withOptions:options];
+        _autoCompleter.autoCompleteDelegate = self;
         _autoCompleter.suggestionsDictionary = [NSArray arrayWithObjects:@"hostel",@"caret",@"carrot",@"house",@"horse", nil];
     }
     return _autoCompleter;
@@ -63,4 +64,17 @@
     [self setSampleLabel:nil];
     [super viewDidUnload];
 }
+
+#pragma mark - AutoCompleteTableViewDelegate
+
+- (NSArray*) suggestionsFor:(NSString*) string{
+    // with the prodided string, build a new array with suggestions - from DB, from a service, etc.
+    return [NSArray arrayWithObjects:@"hostel",@"caret",@"carrot",@"house",@"horse", nil];
+}
+
+- (void) didSelectAutoCompleteSuggestionWithIndex:(NSInteger) index{
+    // invoked when an available suggestion is selected
+    NSLog(@"Suggestion chosen: %d", index);
+}
+
 @end

--- a/AutocompletionTableView_Demo/ACDViewController.m
+++ b/AutocompletionTableView_Demo/ACDViewController.m
@@ -67,14 +67,14 @@
 
 #pragma mark - AutoCompleteTableViewDelegate
 
-- (NSArray*) suggestionsFor:(NSString*) string{
+- (NSArray*) autoCompletion:(AutocompletionTableView*) completer suggestionsFor:(NSString*) string{
     // with the prodided string, build a new array with suggestions - from DB, from a service, etc.
     return [NSArray arrayWithObjects:@"hostel",@"caret",@"carrot",@"house",@"horse", nil];
 }
 
-- (void) didSelectAutoCompleteSuggestionWithIndex:(NSInteger) index{
+- (void) autoCompletion:(AutocompletionTableView*) completer didSelectAutoCompleteSuggestionWithIndex:(NSInteger) index{
     // invoked when an available suggestion is selected
-    NSLog(@"Suggestion chosen: %d", index);
+    NSLog(@"%@ - Suggestion chosen: %d", completer, index);
 }
 
 @end

--- a/Classes/AutocompletionTableView.h
+++ b/Classes/AutocompletionTableView.h
@@ -26,6 +26,8 @@
 // *** FOR FUTURE USE ***
 #define ACOShowSuggestionsOnTop @"ACOShowSuggestionsOnTop"
 
+@class AutocompletionTableView;
+
 /**
  @protocol Delegate methods for AutocompletionTableView
  */
@@ -37,13 +39,13 @@
  @param string the "to-search" term
  @return an array of suggestions built dynamically
  */
-- (NSArray*) suggestionsFor:(NSString*) string;
+- (NSArray*) autoCompletion:(AutocompletionTableView*) completer suggestionsFor:(NSString*) string;
 
 /**
  @method Invoked when user clicked an auto-complete suggestion UITableViewCell.
  @param index the index that was cicked
  */
-- (void) didSelectAutoCompleteSuggestionWithIndex:(NSInteger) index;
+- (void) autoCompletion:(AutocompletionTableView*) completer didSelectAutoCompleteSuggestionWithIndex:(NSInteger) index;
 
 @end
 

--- a/Classes/AutocompletionTableView.h
+++ b/Classes/AutocompletionTableView.h
@@ -26,10 +26,33 @@
 // *** FOR FUTURE USE ***
 #define ACOShowSuggestionsOnTop @"ACOShowSuggestionsOnTop"
 
+/**
+ @protocol Delegate methods for AutocompletionTableView
+ */
+@protocol AutocompletionTableViewDelegate <NSObject>
+
+@required
+/**
+ @method Ask delegate for the suggestions for the provided string - maybe need to ask DB, service, etc.
+ @param string the "to-search" term
+ @return an array of suggestions built dynamically
+ */
+- (NSArray*) suggestionsFor:(NSString*) string;
+
+/**
+ @method Invoked when user clicked an auto-complete suggestion UITableViewCell.
+ @param index the index that was cicked
+ */
+- (void) didSelectAutoCompleteSuggestionWithIndex:(NSInteger) index;
+
+@end
+
 @interface AutocompletionTableView : UITableView <UITableViewDataSource, UITableViewDelegate>
 // Dictionary of NSStrings of your auto-completion terms
 @property (nonatomic, strong) NSArray *suggestionsDictionary; 
 
+// Delegate for AutocompletionTableView
+@property (nonatomic, strong) id<AutocompletionTableViewDelegate> autoCompleteDelegate;
 // Dictionary of auto-completion options (check constants above)
 @property (nonatomic, strong) NSDictionary *options;
 

--- a/Classes/AutocompletionTableView.h
+++ b/Classes/AutocompletionTableView.h
@@ -9,6 +9,10 @@
 
 // Consts for AutoCompleteOptions:
 //
+// if YES - Will avoid the auto-replacement of text when suggestion is clicked
+// if NO - The text will be replaced as usual with the clicked suggestion
+#define ACOAvoidAutoReplaceTextOnField @"ACOAvoidAutoReplaceTextOnField"
+
 // if YES - suggestions will be picked for display case-sensitive
 // if NO - case will be ignored
 #define ACOCaseSensitive @"ACOCaseSensitive"

--- a/Classes/AutocompletionTableView.m
+++ b/Classes/AutocompletionTableView.m
@@ -109,7 +109,10 @@
 #pragma mark - Table view delegate
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    [self.textField setText:[self.suggestionOptions objectAtIndex:indexPath.row]];
+    if (![[self.options valueForKey:ACOAvoidAutoReplaceTextOnField] isEqualToNumber:[NSNumber numberWithInt:1]]) {
+        [self.textField setText:[self.suggestionOptions objectAtIndex:indexPath.row]];
+    }
+    
     [self hideOptionsView];
     
     if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(autoCompletion:didSelectAutoCompleteSuggestionWithIndex:)]) {

--- a/Classes/AutocompletionTableView.m
+++ b/Classes/AutocompletionTableView.m
@@ -60,6 +60,10 @@
     NSMutableArray *tmpArray = [NSMutableArray array];
     NSRange range;
     
+    if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(suggestionsFor:)]) {
+        self.suggestionsDictionary = [_autoCompleteDelegate suggestionsFor:subString];
+    }
+    
     for (NSString *tmpString in self.suggestionsDictionary)
     {
         range = ([[self.options valueForKey:ACOCaseSensitive] isEqualToNumber:[NSNumber numberWithInt:1]]) ? [tmpString rangeOfString:subString] : [tmpString rangeOfString:subString options:NSCaseInsensitiveSearch];
@@ -107,6 +111,10 @@
 {
     [self.textField setText:[self.suggestionOptions objectAtIndex:indexPath.row]];
     [self hideOptionsView];
+    
+    if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(didSelectAutoCompleteSuggestionWithIndex:)]) {
+        [_autoCompleteDelegate didSelectAutoCompleteSuggestionWithIndex:indexPath.row];
+    }
 }
 
 #pragma mark - UITextField delegate

--- a/Classes/AutocompletionTableView.m
+++ b/Classes/AutocompletionTableView.m
@@ -60,8 +60,8 @@
     NSMutableArray *tmpArray = [NSMutableArray array];
     NSRange range;
     
-    if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(suggestionsFor:)]) {
-        self.suggestionsDictionary = [_autoCompleteDelegate suggestionsFor:subString];
+    if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(autoCompletion:suggestionsFor:)]) {
+        self.suggestionsDictionary = [_autoCompleteDelegate autoCompletion:self suggestionsFor:subString];
     }
     
     for (NSString *tmpString in self.suggestionsDictionary)
@@ -112,8 +112,8 @@
     [self.textField setText:[self.suggestionOptions objectAtIndex:indexPath.row]];
     [self hideOptionsView];
     
-    if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(didSelectAutoCompleteSuggestionWithIndex:)]) {
-        [_autoCompleteDelegate didSelectAutoCompleteSuggestionWithIndex:indexPath.row];
+    if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(autoCompletion:didSelectAutoCompleteSuggestionWithIndex:)]) {
+        [_autoCompleteDelegate autoCompletion:self didSelectAutoCompleteSuggestionWithIndex:indexPath.row];
     }
 }
 


### PR DESCRIPTION
Please check if this is useful, otherwise ignore it:

Once the `AutocompletionTableViewDelegate` is implemented, this one may make sense in a case that multiple autoCompleters co-exist and you want to replace all fields at once through the delegate.

Eg.:
1. Imagine you have a list of persons
2. You are searching the `first_name` and you found the `Person*` instance
3. You need to replace the `last_nameTF.text`, `emailTF.text`, `phone_numberTF.text`, etc, all at once
