### PR TITLE
Reverse compatibility for iOS4 and iOS5

### DIFF
--- a/Classes/AutocompletionTableView.m
+++ b/Classes/AutocompletionTableView.m
@@ -110,11 +110,12 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [self.textField setText:[self.suggestionOptions objectAtIndex:indexPath.row]];
-    [self hideOptionsView];
     
     if (_autoCompleteDelegate && [_autoCompleteDelegate respondsToSelector:@selector(didSelectAutoCompleteSuggestionWithIndex:)]) {
         [_autoCompleteDelegate didSelectAutoCompleteSuggestionWithIndex:indexPath.row];
     }
+    
+    [self hideOptionsView];
 }
 
 #pragma mark - UITextField delegate


### PR DESCRIPTION
On iOS6 `UIControlEventEditingChanged` is not triggered when you
change a `textfield.text` programatically but in iOS4/5 is
ALWAYS invoked (manually or programatically). It was assumed on the current implementation and `textFieldValueChanged:` was not invoked incorrectly, causing the `optionsView` to disappear and appear again, if you try to set the field's text on your own code. The quick solution is to invoke the hide AFTER the delegate call
